### PR TITLE
Add Docker support for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+.git
+.github
+.husky
+.vscode
+.idea
+
+# Build + deps
+node_modules
+**/node_modules
+dist
+dist-ssr
+dist-lib
+src/lib/dist
+src/lib/*.tgz
+docs-site/dist
+web/dist
+tsconfig.tsbuildinfo
+
+# Tests / reports
+playwright-report
+test-results
+coverage
+benchmarks/results
+
+# Env / secrets
+.env
+.env.*
+!.env.example
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+pnpm-debug.log*
+
+# OS / misc
+.DS_Store
+*.suo
+*.sw?
+Dockerfile
+.dockerignore
+diff.patch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- Build stage ----------
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy manifests first for better layer caching.
+# Workspace manifests (web, docs-site) are required because the root
+# package.json declares them as workspaces.
+COPY package.json package-lock.json ./
+COPY pnpm-workspace.yaml ./
+COPY web/package.json ./web/package.json
+COPY docs-site/package.json ./docs-site/package.json
+
+# CI avoids running the husky "prepare" hook
+ENV CI=1
+
+# Install using the committed package-lock.json for reproducible builds.
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm \
+    npm ci --no-audit --no-fund
+
+# Copy the rest of the source.
+COPY . .
+
+# Build the SPA (generate-sitemap -> tsc -b -> vite build)
+RUN npm run build
+
+# ---------- Runtime stage ----------
+FROM nginx:1.27-alpine AS runtime
+
+# SPA-aware nginx config (history API fallback + sensible caching)
+COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Built assets
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 3045
+
+# Basic healthcheck against the served index
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3045/ >/dev/null || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen 3045;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip for text assets
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml
+        image/svg+xml;
+
+    # Long-cache hashed static assets emitted by Vite under /assets/
+    location /assets/ {
+        access_log off;
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # Never cache the entry HTML so users get new asset hashes
+    location = /index.html {
+        add_header Cache-Control "no-store";
+    }
+
+    # SPA fallback: serve index.html for any unknown route
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Basic security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+}


### PR DESCRIPTION
## Summary
This PR adds containerization support for OpenFlowKit by introducing a production-ready Docker setup using a multi-stage build process.

The goal is to make deployment easier, faster, and more consistent across environments through containerized delivery. This allows contributors and operators to run the application with minimal setup while improving portability for self-hosting and cloud deployments.

## Changes Included

#### Added `Dockerfile`

Introduced a multi-stage Docker build:

- **Builder stage**
    - Uses `node:20-alpine`
    - Installs workspace dependencies with `npm ci`
    - Builds the application using existing build scripts
- **Runtime stage**
    - Uses lightweight `nginx:1.27-alpine`
    - Serves compiled frontend assets
    - Includes healthcheck support
    - Exposes port `3045`

#### Added `.dockerignore`

Improves build performance and reduces image context size by excluding:

- Git metadata
- local IDE files
- node\_modules
- build artifacts
- logs
- test reports
- environment files

#### Added `nginx/nginx.conf`

Production-ready Nginx configuration for SPA hosting:

- History API fallback for client-side routing
- Long-term caching for hashed static assets
- No-cache for `index.html`
- Gzip compression
- Basic security headers

### Benefits

- Easier deployment using a single container image
- Faster onboarding for new users and contributors
- Consistent runtime behavior across machines
- Simplified CI/CD integration
- Lightweight and production-ready image
- Better portability for cloud or self-hosted environments
- Optimized static asset delivery


## Example Usage

```bash
docker build -t openflowkit .
docker run -p 3045:3045 openflowkit
```
or
```bash
podman build -t openflowkit .
docker run -p 3045:3045 openflowkit
```
## Notes

This setup is designed for production deployment and should work well with platforms such as `Docker`, `Kubernetes`, `Railway`, `Render`, and `DigitalOcean`.