### PR TITLE
Add Docker publish workflow for automated image builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main, master]
+    tags: ["v*.*.*"]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-publish.yml` to automatically build and push
  the Docker image to GitHub Container Registry (GHCR) on every push to `main`/`master`
  and on semver tags (`v*.*.*`)
- Uses the built-in `GITHUB_TOKEN` — no external secrets or Docker Hub account required
- GitHub Actions layer caching (`type=gha`) keeps rebuilds fast

## Image tags produced
| Event | Tag |
|---|---|
| Push to `main` | `ghcr.io/<owner>/openflowkit:main` |
| Push tag `v1.2.3` | `ghcr.io/<owner>/openflowkit:1.2.3` and `:1.2` |
| Any push | `ghcr.io/<owner>/openflowkit:sha-<short-sha>` |

## Test plan
- [x] Workflow triggered on push to `main` and image built successfully
- [x] Image pulled and deployed to Railway — app served correctly at the public URL
