### PR TITLE
fix(mcp): correct stale AWS shapeId in example DSL (database-rds -> d…

### DIFF
--- a/mcp-server/src/resources/index.ts
+++ b/mcp-server/src/resources/index.ts
@@ -14,7 +14,7 @@ direction: TB | LR       # default TB
 [process]      step1: Friendly Label { color: "blue" }
 [decision]     branch: Approved?     { color: "amber" }
 [system]       api:    Internal API
-[architecture] db:     Postgres     { archProvider: "aws", archResourceType: "database-rds" }
+[architecture] db:     Postgres     { archProvider: "aws", archResourceType: "databases-rds" }
 [browser]      web:    Dashboard
 [mobile]       app:    Mobile App
 [note]         n:      Latency 200ms


### PR DESCRIPTION
…atabases-rds)

The example diagram in the MCP resource doc referenced the old `database-rds` shapeId, which was renamed to `databases-rds` in the AWS icon taxonomy update (#61). Align the example so LLMs don't copy an invalid shapeId.