### PR TITLE
docs: fix E2E command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Start here:
 ```bash
 npm run dev        # development server at localhost:5173
 npm run test       # unit tests via Vitest
-npm run test:e2e   # end-to-end tests via Playwright
+npm run e2e        # end-to-end tests via Playwright
 npm run lint       # ESLint + TypeScript type-check
 ```
 


### PR DESCRIPTION
This pull request fixes the E2E command shown in the contributor workflow. The README now references npm run e2e instead of the undefined npm run test:e2e command.