### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ No cloud required. No account required. No lock-in.
 
 <br/>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Vrun-design/openflowkit&type=Date)](https://star-history.com/#Vrun-design/openflowkit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Vrun-design/openflowkit&type=Date)](https://star-history.dera.page/#Vrun-design/openflowkit&Date)
 
 <br/>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because its data source is affected by GitHub stargazer API restrictions. This switches the chart to a working alternative so contributors and users can see the project's growth again.