### PR TITLE
feat(ai): add Gemini 3.5 models, drop 2.5 Flash Lite default

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Flowpilot sits directly in the editor. Describe a system, paste source code, upl
 | Provider            | Default model                              | Why use it                                      |
 | ------------------- | ------------------------------------------ | ----------------------------------------------- |
 | 🦙 **Ollama (local)** | `llama3.2`                               | **Fully offline.** No key, no network, no cost. |
-| Google Gemini       | `gemini-2.5-flash-lite`                    | Free tier available, fast, browser-safe         |
+| Google Gemini       | `gemini-3.5-flash-lite`                    | Free tier available, fast, browser-safe         |
 | OpenAI              | `gpt-5-mini`                               | Best reasoning for complex architectures        |
 | Anthropic Claude    | `claude-sonnet-4-6`                        | Excellent code and system understanding         |
 | Groq                | `meta-llama/llama-4-scout-17b-16e-instruct`| Fastest open-source inference available         |

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1019,11 +1019,26 @@
       },
       "models": {
         "gemini": {
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -939,11 +939,26 @@
       },
       "models": {
         "gemini": {
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "En hızlı · Ücretsiz katman varsayılanı",
             "category": "Hız",
             "badge": "Varsayılan"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "En iyi fiyat/performans dengesi",
+            "category": "Hız"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "En güçlü · Çok modlu",
+            "category": "Akıl Yürütme"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Eski · yeni API anahtarlarında kullanılamaz",
+            "category": "Eski"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/config/aiProviders.test.ts
+++ b/src/config/aiProviders.test.ts
@@ -24,6 +24,14 @@ describe('aiProviders config consistency', () => {
         expect(riskIds).toEqual(providerIds);
     });
 
+    it('defaults the Gemini dropdown to the current flash-lite model', () => {
+        // Google retired gemini-2.5-flash-lite for new API keys, so the default
+        // that the model dropdown falls back to has to be the 3.5 replacement.
+        expect(DEFAULT_MODELS.gemini).toBe('gemini-3.5-flash-lite');
+        expect(PROVIDERS.find((provider) => provider.id === 'gemini')?.defaultModel).toBe('gemini-3.5-flash-lite');
+        expect(PROVIDER_MODELS.gemini[0].id).toBe('gemini-3.5-flash-lite');
+    });
+
     it('provides default base urls for all non-gemini and non-claude providers', () => {
         const required = PROVIDERS
             .map((provider) => provider.id)

--- a/src/config/aiProviders.ts
+++ b/src/config/aiProviders.ts
@@ -12,7 +12,7 @@ export const PROVIDER_BASE_URLS: Record<Exclude<AIProvider, 'gemini' | 'claude' 
 };
 
 export const DEFAULT_MODELS: Record<AIProvider, string> = {
-    gemini: 'gemini-2.5-flash-lite',
+    gemini: 'gemini-3.5-flash-lite',
     openai: 'gpt-5-mini',
     claude: 'claude-sonnet-4-6',
     groq: 'meta-llama/llama-4-scout-17b-16e-instruct',
@@ -159,6 +159,9 @@ export const PROVIDERS: ProviderMeta[] = [
 
 export const PROVIDER_MODELS: Record<AIProvider, { id: string; translateKey: string }[]> = {
     gemini: [
+        { id: 'gemini-3.5-flash-lite', translateKey: 'gemini-3.5-flash-lite' },
+        { id: 'gemini-3.5-flash', translateKey: 'gemini-3.5-flash' },
+        { id: 'gemini-3.5-pro', translateKey: 'gemini-3.5-pro' },
         { id: 'gemini-2.5-flash-lite', translateKey: 'gemini-2.5-flash-lite' },
         { id: 'gemini-2.5-flash', translateKey: 'gemini-2.5-flash' },
         { id: 'gemini-2.5-pro', translateKey: 'gemini-2.5-pro' },

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1019,11 +1019,26 @@
       },
       "models": {
         "gemini": {
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -939,11 +939,26 @@
       },
       "models": {
         "gemini": {
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "En hızlı · Ücretsiz katman varsayılanı",
             "category": "Hız",
             "badge": "Varsayılan"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "En iyi fiyat/performans dengesi",
+            "category": "Hız"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "En güçlü · Çok modlu",
+            "category": "Akıl Yürütme"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Eski · yeni API anahtarlarında kullanılamaz",
+            "category": "Eski"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -952,11 +952,26 @@
             "category": "Legacy",
             "badge": "New"
           },
-          "gemini-2.5-flash-lite": {
-            "label": "2.5 Flash Lite",
+          "gemini-3.5-flash-lite": {
+            "label": "3.5 Flash Lite",
             "hint": "Fastest · Free tier default",
             "category": "Speed",
             "badge": "Default"
+          },
+          "gemini-3.5-flash": {
+            "label": "3.5 Flash",
+            "hint": "Best price/performance balance",
+            "category": "Speed"
+          },
+          "gemini-3.5-pro": {
+            "label": "3.5 Pro",
+            "hint": "Most powerful · Multimodal",
+            "category": "Reasoning"
+          },
+          "gemini-2.5-flash-lite": {
+            "label": "2.5 Flash Lite",
+            "hint": "Legacy · unavailable to new API keys",
+            "category": "Legacy"
           },
           "gemini-2.5-flash": {
             "label": "2.5 Flash",

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -2,7 +2,7 @@ import { GoogleGenAI } from "@google/genai";
 import { getGeminiSystemInstruction } from './geminiSystemInstruction';
 
 /** Default Gemini model — keep in sync with DEFAULT_MODELS in aiService.ts */
-const GEMINI_DEFAULT_MODEL = 'gemini-2.5-flash-lite';
+const GEMINI_DEFAULT_MODEL = 'gemini-3.5-flash-lite';
 
 export interface ChatMessage {
   role: 'user' | 'model';


### PR DESCRIPTION
Google retired gemini-2.5-flash-lite for new API keys, so a fresh key hit a 404 on the Gemini default:

  "This model models/gemini-2.5-flash-lite is no longer available to
   new users. Please update your code to use models/gemini-3.5-flash-lite"

Point DEFAULT_MODELS.gemini and the geminiService hardcoded fallback at gemini-3.5-flash-lite, and add 3.5 Flash and 3.5 Pro to the picker.

gemini-2.5-flash-lite stays selectable so existing keys keep working, but moves to the Legacy group and loses the Default badge.