### PR TITLE
fix(ai): replace decommissioned Groq model IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Flowpilot sits directly in the editor. Describe a system, paste source code, upl
 | Google Gemini       | `gemini-2.5-flash-lite`                    | Free tier available, fast, browser-safe         |
 | OpenAI              | `gpt-5-mini`                               | Best reasoning for complex architectures        |
 | Anthropic Claude    | `claude-sonnet-4-6`                        | Excellent code and system understanding         |
-| Groq                | `meta-llama/llama-4-scout-17b-16e-instruct`| Fastest open-source inference available         |
+| Groq                | `openai/gpt-oss-120b`                      | Fastest open-source inference available         |
 | Mistral             | `mistral-large-latest`                     | Strong European privacy-first alternative       |
 | NVIDIA NIM          | `meta/llama-4-maverick-17b-128e-instruct`  | Enterprise GPU inference                        |
 | Cerebras            | `gpt-oss-120b`                             | Ultra-fast on WSE-3 silicon                     |

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Leistungsfähigstes Modell · Kostenlose Stufe",
+            "category": "Reasoning",
+            "badge": "Gratis"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Schneller · Kostenlose Stufe",
+            "category": "Geschwindigkeit",
+            "badge": "Gratis"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "Fortgeschrittenes Reasoning · Tool-Nutzung",
             "category": "Reasoning"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq Agentensystem · Integrierte Tools",
+            "category": "Leistung"
           }
         },
         "nvidia": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1104,28 +1104,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Most capable · Free tier",
+            "category": "Reasoning",
+            "badge": "Free"
+          },
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Faster · Free tier",
             "category": "Speed",
             "badge": "Free"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
-          },
-          "qwen/qwen3-32b": {
-            "label": "Qwen3 32B",
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
             "hint": "Advanced reasoning · Tool use",
             "category": "Reasoning"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq agentic system · Built-in tools",
+            "category": "Performance"
           }
         },
         "nvidia": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Más capaz · Nivel gratuito",
+            "category": "Razonamiento",
+            "badge": "Gratis"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Más rápido · Nivel gratuito",
+            "category": "Velocidad",
+            "badge": "Gratis"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "Razonamiento avanzado · Uso de herramientas",
+            "category": "Razonamiento"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Sistema agéntico de Groq · Herramientas integradas",
+            "category": "Rendimiento"
           }
         },
         "nvidia": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Le plus performant · Offre gratuite",
+            "category": "Raisonnement",
+            "badge": "Gratuit"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Plus rapide · Offre gratuite",
+            "category": "Vitesse",
+            "badge": "Gratuit"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "Raisonnement avancé · Utilisation d'outils",
+            "category": "Raisonnement"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Système agentique Groq · Outils intégrés",
+            "category": "Performance"
           }
         },
         "nvidia": {

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "最高性能 · 無料枠",
+            "category": "推論",
+            "badge": "無料"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "より高速 · 無料枠",
+            "category": "速度",
+            "badge": "無料"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "高度な推論 · ツール利用",
+            "category": "推論"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq エージェントシステム · ツール内蔵",
+            "category": "パフォーマンス"
           }
         },
         "nvidia": {

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -1024,28 +1024,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Ücretsiz katman · Çok hızlı",
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "En yetenekli · Ücretsiz katman",
+            "category": "Akıl yürütme",
+            "badge": "Ücretsiz"
+          },
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Daha hızlı · Ücretsiz katman",
             "category": "Hız",
             "badge": "Ücretsiz"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "Daha yetenekli · Ücretsiz katman",
-            "category": "Hız",
-            "badge": "Ücretsiz"
-          },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
             "hint": "Gelişmiş akıl yürütme · Araç kullanımı",
-            "category": "Akıl Yürütme"
+            "category": "Akıl yürütme"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Çok yönlü model",
-            "category": "Performans",
-            "badge": "Performans"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq ajan sistemi · Yerleşik araçlar",
+            "category": "Performans"
           }
         },
         "nvidia": {

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "能力最强 · 免费额度",
+            "category": "推理",
+            "badge": "免费"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "更快 · 免费额度",
+            "category": "速度",
+            "badge": "免费"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "高级推理 · 工具调用",
+            "category": "推理"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq 智能体系统 · 内置工具",
+            "category": "性能"
           }
         },
         "nvidia": {

--- a/src/config/aiProviders.ts
+++ b/src/config/aiProviders.ts
@@ -15,7 +15,7 @@ export const DEFAULT_MODELS: Record<AIProvider, string> = {
     gemini: 'gemini-2.5-flash-lite',
     openai: 'gpt-5-mini',
     claude: 'claude-sonnet-4-6',
-    groq: 'meta-llama/llama-4-scout-17b-16e-instruct',
+    groq: 'openai/gpt-oss-120b',
     nvidia: 'meta/llama-4-maverick-17b-128e-instruct',
     cerebras: 'gpt-oss-120b',
     mistral: 'mistral-large-latest',
@@ -179,10 +179,10 @@ export const PROVIDER_MODELS: Record<AIProvider, { id: string; translateKey: str
         { id: 'claude-opus-4-6', translateKey: 'claude-opus-4-6' },
     ],
     groq: [
-        { id: 'meta-llama/llama-4-scout-17b-16e-instruct', translateKey: 'meta-llama/llama-4-scout-17b-16e-instruct' },
-        { id: 'meta-llama/llama-4-maverick-17b-128e-instruct', translateKey: 'meta-llama/llama-4-maverick-17b-128e-instruct' },
-        { id: 'qwen/qwen3-32b', translateKey: 'qwen/qwen3-32b' },
-        { id: 'llama-3.3-70b-versatile', translateKey: 'llama-3.3-70b-versatile' },
+        { id: 'openai/gpt-oss-120b', translateKey: 'openai/gpt-oss-120b' },
+        { id: 'openai/gpt-oss-20b', translateKey: 'openai/gpt-oss-20b' },
+        { id: 'qwen/qwen3.8-27b', translateKey: 'qwen/qwen3.8-27b' },
+        { id: 'groq/compound', translateKey: 'groq/compound' },
     ],
     nvidia: [
         { id: 'meta/llama-4-scout-17b-16e-instruct', translateKey: 'meta/llama-4-scout-17b-16e-instruct' },

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Leistungsfähigstes Modell · Kostenlose Stufe",
+            "category": "Reasoning",
+            "badge": "Gratis"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Schneller · Kostenlose Stufe",
+            "category": "Geschwindigkeit",
+            "badge": "Gratis"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "Fortgeschrittenes Reasoning · Tool-Nutzung",
             "category": "Reasoning"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq Agentensystem · Integrierte Tools",
+            "category": "Leistung"
           }
         },
         "nvidia": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1104,28 +1104,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Most capable · Free tier",
+            "category": "Reasoning",
+            "badge": "Free"
+          },
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Faster · Free tier",
             "category": "Speed",
             "badge": "Free"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
-          },
-          "qwen/qwen3-32b": {
-            "label": "Qwen3 32B",
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
             "hint": "Advanced reasoning · Tool use",
             "category": "Reasoning"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq agentic system · Built-in tools",
+            "category": "Performance"
           }
         },
         "nvidia": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Más capaz · Nivel gratuito",
+            "category": "Razonamiento",
+            "badge": "Gratis"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Más rápido · Nivel gratuito",
+            "category": "Velocidad",
+            "badge": "Gratis"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "Razonamiento avanzado · Uso de herramientas",
+            "category": "Razonamiento"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Sistema agéntico de Groq · Herramientas integradas",
+            "category": "Rendimiento"
           }
         },
         "nvidia": {

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "Le plus performant · Offre gratuite",
+            "category": "Raisonnement",
+            "badge": "Gratuit"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Plus rapide · Offre gratuite",
+            "category": "Vitesse",
+            "badge": "Gratuit"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "Raisonnement avancé · Utilisation d'outils",
+            "category": "Raisonnement"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Système agentique Groq · Outils intégrés",
+            "category": "Performance"
           }
         },
         "nvidia": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "最高性能 · 無料枠",
+            "category": "推論",
+            "badge": "無料"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "より高速 · 無料枠",
+            "category": "速度",
+            "badge": "無料"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "高度な推論 · ツール利用",
+            "category": "推論"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq エージェントシステム · ツール内蔵",
+            "category": "パフォーマンス"
           }
         },
         "nvidia": {

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -1024,28 +1024,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Ücretsiz katman · Çok hızlı",
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "En yetenekli · Ücretsiz katman",
+            "category": "Akıl yürütme",
+            "badge": "Ücretsiz"
+          },
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "Daha hızlı · Ücretsiz katman",
             "category": "Hız",
             "badge": "Ücretsiz"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "Daha yetenekli · Ücretsiz katman",
-            "category": "Hız",
-            "badge": "Ücretsiz"
-          },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
             "hint": "Gelişmiş akıl yürütme · Araç kullanımı",
-            "category": "Akıl Yürütme"
+            "category": "Akıl yürütme"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Çok yönlü model",
-            "category": "Performans",
-            "badge": "Performans"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq ajan sistemi · Yerleşik araçlar",
+            "category": "Performans"
           }
         },
         "nvidia": {

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -1025,28 +1025,27 @@
           }
         },
         "groq": {
-          "meta-llama/llama-4-scout-17b-16e-instruct": {
-            "label": "Llama 4 Scout",
-            "hint": "Free tier · Very fast",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-120b": {
+            "label": "GPT-OSS 120B",
+            "hint": "能力最强 · 免费额度",
+            "category": "推理",
+            "badge": "免费"
           },
-          "meta-llama/llama-4-maverick-17b-128e-instruct": {
-            "label": "Llama 4 Maverick",
-            "hint": "More capable · Free tier",
-            "category": "Speed",
-            "badge": "Free"
+          "openai/gpt-oss-20b": {
+            "label": "GPT-OSS 20B",
+            "hint": "更快 · 免费额度",
+            "category": "速度",
+            "badge": "免费"
           },
-          "qwen/qwen3-32b": {
-            "label": "Qwen 3 32B",
-            "hint": "Advanced reasoning · Tool use",
-            "category": "Reasoning"
+          "qwen/qwen3.8-27b": {
+            "label": "Qwen3.8 27B",
+            "hint": "高级推理 · 工具调用",
+            "category": "推理"
           },
-          "llama-3.3-70b-versatile": {
-            "label": "Llama 3.3 70B Versatile",
-            "hint": "Versatile model",
-            "category": "Performance",
-            "badge": "Performance"
+          "groq/compound": {
+            "label": "Compound",
+            "hint": "Groq 智能体系统 · 内置工具",
+            "category": "性能"
           }
         },
         "nvidia": {


### PR DESCRIPTION
## Summary

Groq is currently unusable — all four model IDs in `PROVIDER_MODELS.groq` have been decommissioned by Groq, so every request fails with `model_not_found`.

Verified against the live Groq API. The previous default:

```
POST https://api.groq.com/openai/v1/chat/completions
{"model": "meta-llama/llama-4-scout-17b-16e-instruct", ...}

→ {"error": {"message": "The model `meta-llama/llama-4-scout-17b-16e-instruct`
   does not exist or you do not have access to it.",
   "type": "invalid_request_error", "code": "model_not_found"}}
```

`GET /openai/v1/models` returns 14 models, and none of the four configured IDs are among them.

## Changes

**`src/config/aiProviders.ts`** — replaced the four retired models. Each replacement was smoke-tested against `/v1/chat/completions` and returns HTTP 200:

| Model | Category |
| --- | --- |
| `openai/gpt-oss-120b` | Reasoning · new default |
| `openai/gpt-oss-20b` | Speed |
| `qwen/qwen3.8-27b` | Reasoning |
| `groq/compound` | Performance |

Of the 14 models Groq returns, only 6 are chat models — the rest are speech-to-text (`whisper-*`), text-to-speech (`canopylabs/orpheus-*`), and safety classifiers (`llama-prompt-guard-2-*`, `gpt-oss-safeguard-20b`). These four are the general-purpose chat models best suited to diagram generation.

**14 locale files** (`src/i18n/locales/` and `public/locales/`, 7 languages each) — model IDs double as i18n keys. `AISettings.tsx:226-229` looks up `settingsModal.ai.models.<provider>.<translateKey>.{label,hint,category,badge}`. Changing a model ID without the matching i18n entry makes the dropdown render raw key paths instead of names, so these move together.

**`README.md`** — the provider table listed the retired model as Groq's default.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 295 files, 1445 tests passing
- [x] Each new model ID returns HTTP 200 from Groq's `/v1/chat/completions`
- [x] Old default confirmed returning `model_not_found`
- [x] `src/i18n/locales/` and `public/locales/` verified byte-identical after the change
- [x] JSON round-trip verified lossless, so the diff touches only the `groq` block
- [ ] Manual: Settings → AI → Groq, confirm the dropdown shows model names (not raw keys) and a generation succeeds

## Notes for reviewers

**Machine-translated strings.** The new `label`/`hint`/`category`/`badge` strings for de, es, fr, ja, tr and zh were written without native-speaker review. They follow the tone of the surrounding entries, but a speaker should sanity-check them. Happy to revert any locale to English placeholders if you'd rather handle translation separately.

**NVIDIA is probably affected too, and is not fixed here.** `PROVIDER_MODELS.nvidia` still lists `meta/llama-4-scout-17b-16e-instruct` and `meta/llama-4-maverick-17b-128e-instruct` — the same retired Llama 4 generation under NVIDIA's naming. Different provider and lifecycle, so I did not assume it's broken and had no NVIDIA key to test with. Worth a follow-up issue.

**Underlying cause.** Hardcoded model lists go stale silently — the user just sees a failed request with no hint that the model no longer exists. Fetching `/v1/models` at runtime with the static list as offline fallback would make this self-healing across every OpenAI-compatible provider. It needs a curation layer (Groq's endpoint returns Whisper and classifier models that don't belong in a diagram-model dropdown), so it's a feature rather than a fix and is deliberately out of scope. Glad to open an issue if there's interest.
