### PR TITLE
refactor(ai): import AIProvider instead of redeclaring it

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -13,8 +13,9 @@ import {
     parseClaudeStreamDelta,
     parseOpenAIStreamDelta,
 } from './aiServiceSchemas';
+import type { AIProvider } from '@/store/types';
 
-export type AIProvider = 'gemini' | 'openai' | 'claude' | 'groq' | 'nvidia' | 'cerebras' | 'mistral' | 'openrouter' | 'ollama' | 'custom';
+export type { AIProvider };
 
 interface AiServiceError {
     code:


### PR DESCRIPTION
## Summary

`AIProvider` is declared twice, independently:

- `src/store/types.ts:41` — the canonical union, imported by the store, settings UI, hooks and zod schemas
- `src/services/aiService.ts:17` — a standalone re-declaration of the same ten string literals

Neither imports the other, so they're unrelated types that happen to match today. Add a provider to one and not the other and **TypeScript stays silent** — both remain valid string-literal unions. The failure surfaces at runtime instead: `getEnvApiKey()` falls through to `undefined`, or `resolveOpenAICompatibleBaseUrl()` throws `Unknown provider`.

Latent right now (both list the same ten providers), but it gets more likely with every provider added.

## Changes

One file, two lines — `src/services/aiService.ts` imports the canonical type and re-exports it:

```ts
import type { AIProvider } from '@/store/types';

export type { AIProvider };
```

The re-export keeps the module's public surface unchanged. Nothing currently imports `AIProvider` from `aiService` (consumers all use `@/store` or `./types`; only `ChatMessage` comes from `aiService`), so a plain import would also compile — happy to drop the re-export if you'd prefer the smaller surface.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 295 files, 1445 tests passing

Drift regression check — temporarily added a fake `'testprovider'` to the canonical union:

- **Before:** `aiService.ts` reported nothing; a provider missing from its switch compiled fine
- **After:** `tsc` reports 7 errors across `aiProviders.ts` (all five `Record<AIProvider, …>` maps), `aiSettings.ts` and `aiSettingsSchemas.ts`

Temporary edit reverted; no behavior change, pure type-level fix.

## Notes for reviewers

The two runtime provider lists were already protected and need no change — `AI_PROVIDERS` in `aiSettings.ts` uses `satisfies readonly AIProvider[]`, and `aiProviderSchema` in `aiSettingsSchemas.ts` uses `satisfies [AIProvider, ...AIProvider[]]`. `aiService.ts` was the only unguarded copy.

One gap this doesn't close: `getEnvApiKey`'s switch has `default: return undefined`, so it isn't exhaustiveness-checked and won't itself error on an unknown provider. The fix works because the shared type propagates into the guarded maps. Tightening that switch would be a separate change — happy to include it if you'd like.
